### PR TITLE
add check for generating duplicate slugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ You will find an example init script in the `scripts` folder. To use, you **must
 
 ## To-do
 * Add tests
-* Add checks for duplicate slugs (i.e. make creation of slugs better)
 
 ## Author
 * [Sam Wierema](http://wiere.ma)


### PR DESCRIPTION
in order to make sure we don't generate duplicate slugs I added a check. It will now keep generating slugs until it finds a non existing one.

Note that this will do something nasty to your server once you've exhausted all possible slugs (within the range of`0123456789abcdefghijklmnopqrstuvwxyz`).

---

_Also, the `rand.Seed` sets a time based seed on startup, I kept generating the same slugs after restart._
